### PR TITLE
listtransactions dummy if set, should be "*"

### DIFF
--- a/src/Commands/CheckPayment.php
+++ b/src/Commands/CheckPayment.php
@@ -52,7 +52,7 @@ class CheckPayment extends Command
     private function checkPayment($bitcoind)
     {
         // get transaction from bitcoind
-        $transactions = $bitcoind->listtransactions('', 50);
+        $transactions = $bitcoind->listtransactions('*', 50);
         if (!is_array($transactions)) {
             $transactions = $transactions->get();
         }


### PR DESCRIPTION
Seems like since biitcoin version CORE 0.16
`$bitcoind->listtransactions('', 50);`
dummy  (string, optional) If set, should be "*" for backwards compatibility
`$bitcoind->listtransactions('*', 50);`
See:
https://github.com/bitcoin/bitcoin/blob/46eb2755d456ca736c1cb7a0922bfece63c5151e/src/wallet/rpcwallet.cpp#L1341
https://github.com/bitcoin/bitcoin/blob/46eb2755d456ca736c1cb7a0922bfece63c5151e/src/wallet/rpcwallet.cpp#L1386